### PR TITLE
#4 handle jing output correctly if _JAVA_OPTIONS env defined

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -14,9 +14,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0', '2.7', '2.6', '2.5', '2.4' ]
+        ruby: [ '3.1', '3.0', '2.7', '2.6', '2.5', '2.4' ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         experimental: [ false ]
+        include:
+          - ruby: head
+            os: ubuntu-latest
+            experimental: true
+          - ruby: head
+            os: windows-latest
+            experimental: true
+          - ruby: head
+            os: macos-latest
+            experimental: true
     steps:
       - uses: actions/checkout@v2
 

--- a/lib/jing.rb
+++ b/lib/jing.rb
@@ -89,9 +89,8 @@ class Jing
 
     out = execute(@options)
     return [] if $?.success? and out.empty?
-    errors = parse_output(out)
-    raise ExecutionError, out if errors.none? # There must have been a problem that was not schema related
-    errors
+
+    parse_output(out)
   end
 
   # Validate an XML document against the schema. To receive a list of validation errors use #validate.
@@ -129,13 +128,18 @@ class Jing
   def parse_output(output)
     errors = []
     output.split("\n").each do |line|
-      if line =~ /\A(.+):(\d+):(\d+):\s+\w+:\s+(.+)\Z/
+      case line
+      when /\A(.+):(\d+):(\d+):\s+\w+:\s+(.+)\Z/
         errors << {
           :source  => $1,
           :line    => $2.to_i,
           :column  => $3.to_i,
           :message => $4
         }
+      when /Picked up _JAVA_OPTIONS: /
+        # ignore diagnostic message
+      else # There must have been a problem that was not schema related
+        raise ExecutionError, line
       end
     end
     errors

--- a/lib/jing.rb
+++ b/lib/jing.rb
@@ -139,7 +139,7 @@ class Jing
       when /Picked up _JAVA_OPTIONS: /
         # ignore diagnostic message
       else # There must have been a problem that was not schema related
-        raise ExecutionError, line
+        raise ExecutionError, output
       end
     end
     errors

--- a/test/test_jing.rb
+++ b/test/test_jing.rb
@@ -113,6 +113,14 @@ class TestJing < MiniTest::Unit::TestCase
     end
   end
 
+  def test_java_options_env
+    java_opts = ENV["_JAVA_OPTIONS"]
+    ENV["_JAVA_OPTIONS"] = "-Djava.io.tmpdir=#{Dir.tmpdir}"
+    errors = Jing.new(RNG_SCHEMA).validate(VALID_XML)
+    assert_equal 0, errors.size
+    ENV["_JAVA_OPTIONS"] = java_opts
+  end
+
   private
   def fakeshell(options = {})
     output = options.delete(:output) || ""

--- a/test/test_jing.rb
+++ b/test/test_jing.rb
@@ -113,12 +113,12 @@ class TestJing < MiniTest::Unit::TestCase
     end
   end
 
-  def test_java_options_env
-    java_opts = ENV["_JAVA_OPTIONS"]
-    ENV["_JAVA_OPTIONS"] = "-Djava.io.tmpdir=#{Dir.tmpdir}"
-    errors = Jing.new(RNG_SCHEMA).validate(VALID_XML)
-    assert_equal 0, errors.size
-    ENV["_JAVA_OPTIONS"] = java_opts
+  def test_java_options_env_diagnostic_message
+    output = "Picked up _JAVA_OPTIONS: -Djava.io.tmpdir=/tmp"
+    fakeshell(:exit => 0, :output => output) {
+      errors = Jing.new(RNG_SCHEMA).validate(VALID_XML)
+      assert_equal 0, errors.size
+    }
   end
 
   private


### PR DESCRIPTION
 - #4 

Any critics/feedback appreciated

P.S. @sshaw also I propose to add `.rubocop.yml` to the repo because the current code style is different from 'default' one + 3.1 ruby and ruby-head to test matrix. Let me know if this ok to make it in the scope of this PR